### PR TITLE
pytest-html reporting and support for imagemagick compare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+report.html
+assets
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ A pytest package implementing perceptualdiff for Selenium tests.
 * Documentation: https://pytest-selenium-pdiff.readthedocs.org.
 
 ## Features
+* Embeds screenshots in [pytest-html](https://pypi.python.org/pypi/pytest-html) reports
+* Supports ImageMagick or perceptualdiff for image comparison.
 
-* TODO
+## Use with pytest-html and pytest-selenium
+By default pytest-selenium will embed a screenshot depicting the current browser state.  This will lead to a duplicated screenshot because of this plugin's behavior.  At this time the best way to exclude the pytest-selenium screenshot is to set the environment variable `SELENIUM_EXCLUDE_DEBUG=screenshot`.
 
 ## Running tests
 1. Ensure `tox` is installed with `pip install tox`

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts=-s -vv --driver=PhantomJS --html=report.html --self-contained-html tests/
+addopts=-s -vv --driver=PhantomJS --html=report.html --self-contained-html --cov-config .coveragerc --cov pytest_selenium_pdiff --cov-report xml tests/
 pep8maxlinelength = 120

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts=-s -vv --driver=PhantomJS tests/
+addopts=-s -vv --driver=PhantomJS --html=report.html --self-contained-html tests/
 pep8maxlinelength = 120

--- a/pytest_selenium_pdiff/__init__.py
+++ b/pytest_selenium_pdiff/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = 'Phil Plante'
 __email__ = 'phil@rentlytics.com'
-__version__ = '0.2.8'
+__version__ = '0.3.0'
 
 # noinspection PyUnresolvedReferences
 from .pytest_selenium_pdiff import *

--- a/pytest_selenium_pdiff/assertions.py
+++ b/pytest_selenium_pdiff/assertions.py
@@ -28,24 +28,16 @@ def screenshot_matches(driver, screenshot_name):
 
     if have_stored_screenshot:
         if settings['USE_IMAGEMAGICK']:
-            result = use_imagemagick_compare(captured_screenshot, expected_screenshot, pdiff_comparison)
+            matches_expected = use_imagemagick_compare(captured_screenshot, expected_screenshot, pdiff_comparison)
         elif settings['USE_PERCEPTUALDIFF']:
-            result = use_perceptualdiff(captured_screenshot, expected_screenshot, pdiff_comparison)
+            matches_expected = use_perceptualdiff(captured_screenshot, expected_screenshot, pdiff_comparison)
 
-        if result.exit_code != 0:
-            error_message = str(result).strip()
-
+        if not matches_expected:
             if os.path.exists(pdiff_comparison):
-                raise exceptions.ScreenshotMismatchWithDiff(screenshot_name,
-                                                            expected_screenshot,
-                                                            captured_screenshot,
-                                                            pdiff_comparison,
-                                                            error_message)
+                raise exceptions.ScreenshotMismatchWithDiff(screenshot_name, expected_screenshot, captured_screenshot,
+                                                            pdiff_comparison)
             else:
-                raise exceptions.ScreenshotMismatch(screenshot_name,
-                                                    expected_screenshot,
-                                                    captured_screenshot,
-                                                    error_message)
+                raise exceptions.ScreenshotMismatch(screenshot_name, expected_screenshot, captured_screenshot)
     elif settings['ALLOW_SCREENSHOT_CAPTURE']:
         shutil.move(captured_screenshot, expected_screenshot)
 
@@ -55,24 +47,33 @@ def screenshot_matches(driver, screenshot_name):
 def use_imagemagick_compare(captured_screenshot, expected_screenshot, pdiff_comparison):
     from sh import compare
 
-    return compare(
+    # Arguments list: http://www.imagemagick.org/script/compare.php
+    result = compare(
         expected_screenshot,
         captured_screenshot,
-        '-highlight-color',
-        'blue',
-        '-compose',
-        'src-over',
+        '-metric', 'AE',
+        '-highlight-color', 'blue',
+        '-compose', 'src-over',
         pdiff_comparison,
         _ok_code=[0, 1, 2]
     )
+
+    if result.exit_code == 2:
+        return False
+
+    pixel_errors = int(result.stderr)
+
+    return pixel_errors == 0
 
 
 def use_perceptualdiff(captured_screenshot, expected_screenshot, pdiff_comparison):
     from sh import perceptualdiff
 
-    return perceptualdiff(
+    result = perceptualdiff(
         '-output', pdiff_comparison,
         expected_screenshot,
         captured_screenshot,
         _ok_code=[0, 1]
     )
+
+    return result.exit_code == 0

--- a/pytest_selenium_pdiff/assertions.py
+++ b/pytest_selenium_pdiff/assertions.py
@@ -12,25 +12,25 @@ def screenshot_matches(driver, screenshot_name, pixel_threshold=1):
     storage_path = settings['SCREENSHOTS_PATH']
     artifacts_path = settings['PDIFF_PATH']
 
-    stored_screenshot = os.path.join(storage_path, screenshot_name + '.png')
-    diff_output_path = os.path.join(artifacts_path, screenshot_name + '.diff.png')
+    expected_screenshot = os.path.join(storage_path, screenshot_name + '.png')
+    pdiff_comparison = os.path.join(artifacts_path, screenshot_name + '.diff.png')
     captured_screenshot = os.path.join(artifacts_path, screenshot_name + '.captured.png')
 
-    ensure_path_exists(os.path.dirname(stored_screenshot))
-    ensure_path_exists(os.path.dirname(diff_output_path))
+    ensure_path_exists(os.path.dirname(expected_screenshot))
+    ensure_path_exists(os.path.dirname(pdiff_comparison))
 
-    have_stored_screenshot = os.path.exists(stored_screenshot)
+    have_stored_screenshot = os.path.exists(expected_screenshot)
 
     if not have_stored_screenshot and not settings['ALLOW_SCREENSHOT_CAPTURE']:
-        raise exceptions.MissingScreenshot(screenshot_name, stored_screenshot)
+        raise exceptions.MissingScreenshot(screenshot_name, expected_screenshot)
 
     driver.get_screenshot_as_file(captured_screenshot)
 
     if have_stored_screenshot:
         result = perceptualdiff(
-            '-output', diff_output_path,
+            '-output', pdiff_comparison,
             '-threshold', pixel_threshold,
-            stored_screenshot,
+            expected_screenshot,
             captured_screenshot,
             _ok_code=[0, 1]
         )
@@ -38,14 +38,18 @@ def screenshot_matches(driver, screenshot_name, pixel_threshold=1):
         if result.exit_code == 1:
             error_message = str(result).strip()
 
-            if os.path.exists(diff_output_path):
+            if os.path.exists(pdiff_comparison):
                 raise exceptions.ScreenshotMismatchWithDiff(screenshot_name,
-                                                            stored_screenshot,
-                                                            diff_output_path,
+                                                            expected_screenshot,
+                                                            captured_screenshot,
+                                                            pdiff_comparison,
                                                             error_message)
             else:
-                raise exceptions.ScreenshotMismatch(screenshot_name, stored_screenshot, error_message)
+                raise exceptions.ScreenshotMismatch(screenshot_name,
+                                                    expected_screenshot,
+                                                    captured_screenshot,
+                                                    error_message)
     elif settings['ALLOW_SCREENSHOT_CAPTURE']:
-        shutil.move(captured_screenshot, stored_screenshot)
+        shutil.move(captured_screenshot, expected_screenshot)
 
     return True

--- a/pytest_selenium_pdiff/exceptions.py
+++ b/pytest_selenium_pdiff/exceptions.py
@@ -11,29 +11,42 @@ class MissingScreenshot(AssertionError):
 
 
 class ScreenshotMismatch(AssertionError):
-    def __init__(self, screenshot_name, screenshot_path, pdiff_output, *args, **kwargs):
+    def __init__(self, screenshot_name, expected_screenshot, captured_screenshot, pdiff_output, *args, **kwargs):
         message = 'Captured screenshot named "{}", does not match stored ' \
                   'screenshot "{}", perceptualdiff returned: "{}".  '
 
         message = message.format(
             screenshot_name,
-            screenshot_path,
+            expected_screenshot,
             pdiff_output
         )
+
+        self.screenshot_name = screenshot_name
+        self.expected_screenshot = expected_screenshot
+        self.captured_screenshot = captured_screenshot
+        self.pdiff_output = pdiff_output
 
         super(ScreenshotMismatch, self).__init__(message, *args, **kwargs)
 
 
 class ScreenshotMismatchWithDiff(AssertionError):
-    def __init__(self, screenshot_name, screenshot_path, diff_path, pdiff_output, *args, **kwargs):
+    def __init__(self, screenshot_name, expected_screenshot,
+                 captured_screenshot, pdiff_comparison,
+                 pdiff_output, *args, **kwargs):
         message = 'Captured screenshot named "{}", does not match stored screenshot "{}".  ' \
                   'Diff is available at: "{}", perceptualdiff returned: {}.'
 
         message = message.format(
             screenshot_name,
-            screenshot_path,
-            diff_path,
+            expected_screenshot,
+            pdiff_comparison,
             pdiff_output
         )
+
+        self.screenshot_name = screenshot_name
+        self.expected_screenshot = expected_screenshot
+        self.captured_screenshot = captured_screenshot
+        self.pdiff_comparison = pdiff_comparison
+        self.pdiff_output = pdiff_output
 
         super(ScreenshotMismatchWithDiff, self).__init__(message, *args, **kwargs)

--- a/pytest_selenium_pdiff/exceptions.py
+++ b/pytest_selenium_pdiff/exceptions.py
@@ -11,46 +11,30 @@ class MissingScreenshot(AssertionError):
 
 
 class ScreenshotMismatch(AssertionError):
-    def __init__(self, screenshot_name, expected_screenshot, captured_screenshot, command_output, *args, **kwargs):
-        message = 'Captured screenshot named "{}", does not match stored ' \
-                  'screenshot "{}", perceptualdiff returned: "{}".  '
-
-        message = message.format(
-            screenshot_name,
+    def __init__(self, screenshot_name, expected_screenshot, actual_screenshot, *args, **kwargs):
+        message = 'Expected "{}" to match reference screenshot "{}".'.format(
+            actual_screenshot,
             expected_screenshot,
-            command_output
         )
 
         self.screenshot_name = screenshot_name
         self.expected_screenshot = expected_screenshot
-        self.captured_screenshot = captured_screenshot
-        self.command_output = command_output
+        self.actual_screenshot = actual_screenshot
 
         super(ScreenshotMismatch, self).__init__(message, *args, **kwargs)
 
 
 class ScreenshotMismatchWithDiff(AssertionError):
-    def __init__(self, screenshot_name, expected_screenshot,
-                 actual_screenshot, screenshot_comparison,
-                 command_output, *args, **kwargs):
-        message = 'Expected "{}" to match reference screenshot "{}", highlighted differences "{}".  Command output: {}'.format(
+    def __init__(self, screenshot_name, expected_screenshot, actual_screenshot, screenshot_comparison, *args, **kwargs):
+        message = 'Expected "{}" to match reference screenshot "{}", highlighted differences "{}".'.format(
             actual_screenshot,
             expected_screenshot,
             screenshot_comparison,
-            command_output
-        )
-
-        message = message.format(
-            screenshot_name,
-            expected_screenshot,
-            screenshot_comparison,
-            command_output
         )
 
         self.screenshot_name = screenshot_name
         self.expected_screenshot = expected_screenshot
-        self.captured_screenshot = actual_screenshot
+        self.actual_screenshot = actual_screenshot
         self.screenshot_comparison = screenshot_comparison
-        self.command_output = command_output
 
         super(ScreenshotMismatchWithDiff, self).__init__(message, *args, **kwargs)

--- a/pytest_selenium_pdiff/exceptions.py
+++ b/pytest_selenium_pdiff/exceptions.py
@@ -11,42 +11,46 @@ class MissingScreenshot(AssertionError):
 
 
 class ScreenshotMismatch(AssertionError):
-    def __init__(self, screenshot_name, expected_screenshot, captured_screenshot, pdiff_output, *args, **kwargs):
+    def __init__(self, screenshot_name, expected_screenshot, captured_screenshot, command_output, *args, **kwargs):
         message = 'Captured screenshot named "{}", does not match stored ' \
                   'screenshot "{}", perceptualdiff returned: "{}".  '
 
         message = message.format(
             screenshot_name,
             expected_screenshot,
-            pdiff_output
+            command_output
         )
 
         self.screenshot_name = screenshot_name
         self.expected_screenshot = expected_screenshot
         self.captured_screenshot = captured_screenshot
-        self.pdiff_output = pdiff_output
+        self.command_output = command_output
 
         super(ScreenshotMismatch, self).__init__(message, *args, **kwargs)
 
 
 class ScreenshotMismatchWithDiff(AssertionError):
     def __init__(self, screenshot_name, expected_screenshot,
-                 captured_screenshot, pdiff_comparison,
-                 pdiff_output, *args, **kwargs):
-        message = 'Captured screenshot named "{}", does not match stored screenshot "{}".  ' \
-                  'Diff is available at: "{}", perceptualdiff returned: {}.'
+                 actual_screenshot, screenshot_comparison,
+                 command_output, *args, **kwargs):
+        message = 'Expected "{}" to match reference screenshot "{}", highlighted differences "{}".  Command output: {}'.format(
+            actual_screenshot,
+            expected_screenshot,
+            screenshot_comparison,
+            command_output
+        )
 
         message = message.format(
             screenshot_name,
             expected_screenshot,
-            pdiff_comparison,
-            pdiff_output
+            screenshot_comparison,
+            command_output
         )
 
         self.screenshot_name = screenshot_name
         self.expected_screenshot = expected_screenshot
-        self.captured_screenshot = captured_screenshot
-        self.pdiff_comparison = pdiff_comparison
-        self.pdiff_output = pdiff_output
+        self.captured_screenshot = actual_screenshot
+        self.screenshot_comparison = screenshot_comparison
+        self.command_output = command_output
 
         super(ScreenshotMismatchWithDiff, self).__init__(message, *args, **kwargs)

--- a/pytest_selenium_pdiff/pytest_selenium_pdiff.py
+++ b/pytest_selenium_pdiff/pytest_selenium_pdiff.py
@@ -92,7 +92,7 @@ def pytest_runtest_makereport(item, call):
                     ))
 
                 report.extra.append(pytest_html.extras.image(
-                    get_image_as_base64(exception.captured_screenshot),
+                    get_image_as_base64(exception.actual_screenshot),
                     'PDIFF: Actual'
                 ))
         else:

--- a/pytest_selenium_pdiff/pytest_selenium_pdiff.py
+++ b/pytest_selenium_pdiff/pytest_selenium_pdiff.py
@@ -1,10 +1,20 @@
+import base64
 import os
+
+import pytest
+
+from . import exceptions
 
 settings = {
     'SCREENSHOTS_PATH': None,
     'PDIFF_PATH': None,
     'ALLOW_SCREENSHOT_CAPTURE': False
 }
+
+SCREENSHOT_EXCEPTION_TYPES = (
+    exceptions.ScreenshotMismatchWithDiff,
+    exceptions.ScreenshotMismatch
+)
 
 
 def pytest_addoption(parser):
@@ -19,6 +29,12 @@ def pytest_addoption(parser):
                      metavar='path',
                      help='path to pdiff output')
 
+    selenium_exclude_debug = os.environ.get('SELENIUM_EXCLUDE_DEBUG', '')
+    if 'screenshot' not in selenium_exclude_debug:
+        selenium_exclude_debug += ' screenshot'
+
+    os.environ['SELENIUM_EXCLUDE_DEBUG'] = selenium_exclude_debug
+
 
 def pytest_configure(config):
     settings['SCREENSHOTS_PATH'] = config.getoption('screenshots_path')
@@ -27,3 +43,41 @@ def pytest_configure(config):
 
     if 'ALLOW_SCREENSHOT_CAPTURE' in os.environ:
         settings['ALLOW_SCREENSHOT_CAPTURE'] = True
+
+
+@pytest.mark.hookwrapper
+def pytest_runtest_makereport(item, call):
+    pytest_html = item.config.pluginmanager.getplugin('html')
+    outcome = yield
+    report = outcome.get_result()
+    report.extra = getattr(report, 'extra', [])
+
+    xfail = hasattr(report, 'wasxfail')
+    failure = (report.skipped and xfail) or (report.failed and not xfail)
+
+    if failure and call.excinfo:
+        exception = call.excinfo.value
+
+        if isinstance(exception, SCREENSHOT_EXCEPTION_TYPES):
+            report.extra.append(pytest_html.extras.image(
+                get_image_as_base64(exception.expected_screenshot),
+                'PDIFF: Expected'
+            ))
+
+            if isinstance(exception, exceptions.ScreenshotMismatchWithDiff):
+                report.extra.append(pytest_html.extras.image(
+                    get_image_as_base64(exception.pdiff_comparison),
+                    'PDIFF: Comparison'
+                ))
+
+            report.extra.append(pytest_html.extras.image(
+                get_image_as_base64(exception.captured_screenshot),
+                'PDIFF: Actual'
+            ))
+
+
+def get_image_as_base64(filename):
+    with open(filename, 'rb') as fp:
+        content = fp.read()
+        b64_image = base64.b64encode(content).decode('ascii')
+    return b64_image

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,3 +14,4 @@ pytest-html==1.10.0
 pytest-selenium==1.3.1
 pytest-variables==1.4
 sh==1.11
+mock==2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,5 @@ universal = 1
 [flake8]
 exclude = docs
 
+[aliases]
+test = pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.8
+current_version = 0.3.0
 commit = True
 tag = True
 
@@ -19,3 +19,4 @@ exclude = docs
 
 [aliases]
 test = pytest
+

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ test_requirements = [
 
 setup(
     name='pytest-selenium-pdiff',
-    version='0.2.8',
+    version='0.3.0',
     description="A pytest package implementing perceptualdiff for Selenium tests.",
     long_description=readme + '\n\n' + history,
     author="Phil Plante",

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ setup(
         'Programming Language :: Python :: 3.5',
         "Framework :: Pytest",
     ],
+    setup_requires=[
+        'pytest-runner',
+    ],
     test_suite='tests',
     tests_require=test_requirements
 )

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,13 @@ with open('HISTORY.md') as history_file:
 
 requirements = [
     'pytest>=2.9.2',
-    'pytest-selenium>=1.2.1',
+    'pytest-selenium>=1.3.1',
     # used to call perceptualdiff util
     'sh==1.11'
 ]
 
 test_requirements = [
+    'pytest-cov>=2.3.1'
 ]
 
 setup(

--- a/tests/fixtures/page1-changed.html
+++ b/tests/fixtures/page1-changed.html
@@ -3,10 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
+    <style>
+        body {
+            font-size: 32pt;
+        }
+    </style>
 </head>
 <body>
 This is a <b>test</b> page.
-<div style="background: red; color: yellowgreen; padding: 10px;">
+<div style="color: yellowgreen;">
     It has a second paragraph.
 </div>
 </body>

--- a/tests/fixtures/page1.html
+++ b/tests/fixtures/page1.html
@@ -3,6 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
+    <style>
+        body {
+            font-size: 32pt;
+        }
+    </style>
 </head>
 <body>
 This is a test page.

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -1,0 +1,103 @@
+import os
+
+import mock as mock
+import pytest
+
+from pytest_selenium_pdiff import exceptions, screenshot_matches, settings
+
+
+def setup_selenium_session(selenium, tmpdir):
+    selenium.implicitly_wait(5)
+    selenium.set_window_size(1200, 800)
+    selenium.get('./tests/fixtures/page1.html')
+
+    settings['ALLOW_SCREENSHOT_CAPTURE'] = True
+    settings['SCREENSHOTS_PATH'] = str(tmpdir.join('screenshots/'))
+    settings['PDIFF_PATH'] = str(tmpdir.join('pdiff/'))
+
+
+def test_screenshot_matches__raises_when_capture_is_disabled(selenium, tmpdir):
+    setup_selenium_session(selenium, tmpdir)
+
+    settings['ALLOW_SCREENSHOT_CAPTURE'] = False
+
+    with pytest.raises(exceptions.MissingScreenshot):
+        assert screenshot_matches(selenium, 'testing')
+
+
+def test_screenshot_matches__screenshots_saved_when_capture_is_enabled(selenium, tmpdir):
+    setup_selenium_session(selenium, tmpdir)
+
+    settings['USE_IMAGEMAGICK'] = True
+    settings['USE_PERCEPTUALDIFF'] = False
+
+    assert screenshot_matches(selenium, 'testing')
+    assert os.path.exists(os.path.join(settings['SCREENSHOTS_PATH'], 'testing.png')) is True
+
+    assert screenshot_matches(selenium, 'subdir/testing')
+    assert os.path.exists(os.path.join(settings['SCREENSHOTS_PATH'], 'subdir/testing.png')) is True
+
+
+def test_screenshot_matches__switches_between_backends(selenium, tmpdir):
+    setup_selenium_session(selenium, tmpdir)
+
+    screenshot_matches(selenium, 'testing')
+
+    settings['USE_IMAGEMAGICK'] = True
+    settings['USE_PERCEPTUALDIFF'] = False
+
+    with mock.patch('sh.compare') as mock_compare:
+        result = mock.MagicMock()
+        result.exit_code = 0
+        mock_compare.return_value = result
+        screenshot_matches(selenium, 'testing')
+
+        assert mock_compare.called
+
+    settings['USE_IMAGEMAGICK'] = False
+    settings['USE_PERCEPTUALDIFF'] = True
+
+    with mock.patch('sh.perceptualdiff') as mock_pdiff:
+        result = mock.MagicMock()
+        result.exit_code = 0
+        mock_pdiff.return_value = result
+
+        screenshot_matches(selenium, 'testing')
+
+        assert mock_pdiff.called
+
+
+def test_screenshot_matches__raises_when_mismatch_detected(selenium, tmpdir):
+    setup_selenium_session(selenium, tmpdir)
+
+    screenshot_matches(selenium, 'testing')
+    selenium.get('./tests/fixtures/page1-changed.html')
+    selenium.find_element_by_tag_name('body').text.index("It has a second paragraph.")
+
+    with pytest.raises(exceptions.ScreenshotMismatchWithDiff):
+        assert screenshot_matches(selenium, 'testing')
+
+    captured_path = os.path.join(settings['PDIFF_PATH'], 'testing.captured.png')
+    pdiff_path = os.path.join(settings['PDIFF_PATH'], 'testing.diff.png')
+
+    assert os.path.exists(captured_path)
+    assert os.path.exists(pdiff_path)
+
+
+def test_screenshot_matches__raises_when_images_are_different_sizes(selenium, tmpdir):
+    setup_selenium_session(selenium, tmpdir)
+
+    screenshot_matches(selenium, 'testing-size')
+
+    selenium.set_window_size(1200, 900)
+    selenium.get('./tests/fixtures/page1-changed.html')
+    selenium.find_element_by_tag_name('body').text.index("It has a second paragraph.")
+
+    with pytest.raises(exceptions.ScreenshotMismatch):
+        assert screenshot_matches(selenium, 'testing-size')
+
+    captured_path = os.path.join(settings['PDIFF_PATH'], 'testing-size.captured.png')
+    pdiff_path = os.path.join(settings['PDIFF_PATH'], 'testing-size.diff.png')
+
+    assert os.path.exists(captured_path)
+    assert os.path.exists(pdiff_path) is False

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -49,6 +49,8 @@ def test_screenshot_matches__switches_between_backends(selenium, tmpdir):
     with mock.patch('sh.compare') as mock_compare:
         result = mock.MagicMock()
         result.exit_code = 0
+        result.stderr = b'0'
+
         mock_compare.return_value = result
         screenshot_matches(selenium, 'testing')
 

--- a/tests/test_pytest_selenium_pdiff.py
+++ b/tests/test_pytest_selenium_pdiff.py
@@ -63,3 +63,40 @@ def test_screenshot_matches(selenium, tmpdir):
 
     assert os.path.exists(captured_path)
     assert os.path.exists(pdiff_path) is False
+
+
+def xtest_screenshot_breaks(selenium, tmpdir):
+    selenium.implicitly_wait(5)
+    selenium.set_window_size(1200, 800)
+
+    selenium.get('./tests/fixtures/page1.html')
+
+    settings['SCREENSHOTS_PATH'] = str(tmpdir.join('screenshots/'))
+    settings['PDIFF_PATH'] = str(tmpdir.join('pdiff/'))
+
+    settings['ALLOW_SCREENSHOT_CAPTURE'] = True
+
+    assert screenshot_matches(selenium, 'testing')
+
+    selenium.get('./tests/fixtures/page1-changed.html')
+    selenium.find_element_by_tag_name('body').text.index("It has a second paragraph.")
+    assert screenshot_matches(selenium, 'testing')
+
+
+def xtest_screenshot_breaks_on_size(selenium, tmpdir):
+    selenium.implicitly_wait(5)
+    selenium.set_window_size(1200, 800)
+
+    selenium.get('./tests/fixtures/page1.html')
+
+    settings['SCREENSHOTS_PATH'] = str(tmpdir.join('screenshots/'))
+    settings['PDIFF_PATH'] = str(tmpdir.join('pdiff/'))
+
+    settings['ALLOW_SCREENSHOT_CAPTURE'] = True
+
+    screenshot_matches(selenium, 'testing-size')
+
+    selenium.set_window_size(1200, 900)
+    selenium.get('./tests/fixtures/page1-changed.html')
+    selenium.find_element_by_tag_name('body').text.index("It has a second paragraph.")
+    assert screenshot_matches(selenium, 'testing-size')

--- a/tests/test_pytest_selenium_pdiff.py
+++ b/tests/test_pytest_selenium_pdiff.py
@@ -1,102 +1,25 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
+from copy import deepcopy
 
-import pytest
-
-from pytest_selenium_pdiff import exceptions, screenshot_matches, settings, utils
+from pytest_selenium_pdiff import *
 
 
-def test_ensure_path_exists(tmpdir):
-    path = os.path.join(str(tmpdir), 'subdir')
+def test_pytest_report_header():
+    old_settings = deepcopy(settings)
 
-    assert os.path.exists(path) is False
+    settings['USE_IMAGEMAGICK'] = True
+    settings['USE_PERCEPTUALDIFF'] = True
 
-    utils.ensure_path_exists(path)
+    assert 'ImageMagick' in pytest_report_header(None)
 
-    assert os.path.exists(path) is True
+    settings['USE_IMAGEMAGICK'] = False
 
+    assert 'perceptualdiff' in pytest_report_header(None)
 
-def test_screenshot_matches(selenium, tmpdir):
-    selenium.implicitly_wait(5)
-    selenium.set_window_size(1200, 800)
+    settings['USE_PERCEPTUALDIFF'] = False
 
-    selenium.get('./tests/fixtures/page1.html')
+    with pytest.raises(Exception) as e:
+        pytest_report_header(None)
 
-    settings['SCREENSHOTS_PATH'] = str(tmpdir.join('screenshots/'))
-    settings['PDIFF_PATH'] = str(tmpdir.join('pdiff/'))
-
-    with pytest.raises(exceptions.MissingScreenshot):
-        assert screenshot_matches(selenium, 'testing')
-
-    settings['ALLOW_SCREENSHOT_CAPTURE'] = True
-
-    assert screenshot_matches(selenium, 'testing')
-    assert os.path.exists(os.path.join(settings['SCREENSHOTS_PATH'], 'testing.png')) is True
-
-    assert screenshot_matches(selenium, 'subdir/testing')
-    assert os.path.exists(os.path.join(settings['SCREENSHOTS_PATH'], 'subdir/testing.png')) is True
-
-    with pytest.raises(exceptions.ScreenshotMismatchWithDiff):
-        selenium.get('./tests/fixtures/page1-changed.html')
-        selenium.find_element_by_tag_name('body').text.index("It has a second paragraph.")
-        assert screenshot_matches(selenium, 'testing')
-
-    captured_path = os.path.join(settings['PDIFF_PATH'], 'testing.captured.png')
-    pdiff_path = os.path.join(settings['PDIFF_PATH'], 'testing.diff.png')
-
-    assert os.path.exists(captured_path)
-    assert os.path.exists(pdiff_path)
-
-    assert screenshot_matches(selenium, 'testing', pixel_threshold=49500)
-
-    with pytest.raises(exceptions.ScreenshotMismatch):
-        screenshot_matches(selenium, 'testing-size')
-
-        selenium.set_window_size(1200, 900)
-        selenium.get('./tests/fixtures/page1-changed.html')
-        selenium.find_element_by_tag_name('body').text.index("It has a second paragraph.")
-        assert screenshot_matches(selenium, 'testing-size')
-
-    captured_path = os.path.join(settings['PDIFF_PATH'], 'testing-size.captured.png')
-    pdiff_path = os.path.join(settings['PDIFF_PATH'], 'testing-size.diff.png')
-
-    assert os.path.exists(captured_path)
-    assert os.path.exists(pdiff_path) is False
-
-
-def xtest_screenshot_breaks(selenium, tmpdir):
-    selenium.implicitly_wait(5)
-    selenium.set_window_size(1200, 800)
-
-    selenium.get('./tests/fixtures/page1.html')
-
-    settings['SCREENSHOTS_PATH'] = str(tmpdir.join('screenshots/'))
-    settings['PDIFF_PATH'] = str(tmpdir.join('pdiff/'))
-
-    settings['ALLOW_SCREENSHOT_CAPTURE'] = True
-
-    assert screenshot_matches(selenium, 'testing')
-
-    selenium.get('./tests/fixtures/page1-changed.html')
-    selenium.find_element_by_tag_name('body').text.index("It has a second paragraph.")
-    assert screenshot_matches(selenium, 'testing')
-
-
-def xtest_screenshot_breaks_on_size(selenium, tmpdir):
-    selenium.implicitly_wait(5)
-    selenium.set_window_size(1200, 800)
-
-    selenium.get('./tests/fixtures/page1.html')
-
-    settings['SCREENSHOTS_PATH'] = str(tmpdir.join('screenshots/'))
-    settings['PDIFF_PATH'] = str(tmpdir.join('pdiff/'))
-
-    settings['ALLOW_SCREENSHOT_CAPTURE'] = True
-
-    screenshot_matches(selenium, 'testing-size')
-
-    selenium.set_window_size(1200, 900)
-    selenium.get('./tests/fixtures/page1-changed.html')
-    selenium.find_element_by_tag_name('body').text.index("It has a second paragraph.")
-    assert screenshot_matches(selenium, 'testing-size')
+    settings.update(old_settings)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+import os
+
+from pytest_selenium_pdiff import utils
+
+def test_ensure_path_exists(tmpdir):
+    path = os.path.join(str(tmpdir), 'subdir')
+
+    assert os.path.exists(path) is False
+
+    utils.ensure_path_exists(path)
+
+    assert os.path.exists(path) is True


### PR DESCRIPTION
#### CHANGES
* Added support for embedding images into a HTML report via pytest-html
* Added support for ImageMagick's `compare` utility, which is faster than `perceptualdiff` in my limited testing.

#### DESCRIPTION
Comparing the images of expected/actual/diff screenshots is quite challenging on most CI systems.  Luckily pytest-html creates fancy HTML reports, which can have images embedded in them.  This is great because it will let us check a single page for all the test results.

I was also playing around with ImageMagick's `compare` binary and have found it to be about 1.5 seconds faster when comparing the same images.  So I have added support, which defaults to `compare` and falls back to `perceptualdiff`. 

Assertion messages have also become more useful as they list the full path of all expected/actual/diff images.


### pytest-html sample with embedded images:

![image](https://cloud.githubusercontent.com/assets/58743/18495262/6f57b4f6-79d1-11e6-9496-bef82c7675f1.png)
